### PR TITLE
SLING-10441 : use dedicated 'discovery' thread pool for scheduler ins…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
  		<dependency>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.discovery.commons</artifactId>
-			<version>1.0.20</version>
+			<version>1.0.23-SNAPSHOT</version>
   		</dependency>
         <!-- besides including discovery.commons' normal jar above, 
               for testing a few test helper classes are also reused.
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.discovery.commons</artifactId>
-            <version>1.0.20</version>
+            <version>1.0.23-SNAPSHOT</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -201,9 +201,9 @@
             <scope>provided</scope>
 		</dependency>
         <dependency>
-        	<groupId>org.apache.sling</groupId>
-        	<artifactId>org.apache.sling.commons.scheduler</artifactId>
-        	<version>2.3.4</version>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.scheduler</artifactId>
+            <version>2.5.0</version>
             <scope>provided</scope>
         </dependency>
 		<dependency>

--- a/src/main/java/org/apache/sling/discovery/base/commons/BaseViewChecker.java
+++ b/src/main/java/org/apache/sling/discovery/base/commons/BaseViewChecker.java
@@ -20,7 +20,6 @@ package org.apache.sling.discovery.base.commons;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,7 +177,7 @@ public abstract class BaseViewChecker implements ViewChecker, Runnable {
             // 'fireJob' checks for a job from the same job-class to already exist
             // 'fireJobAt' though allows to pass a name for the job - which can be made unique, thus does not conflict/already-exist
             logger.info("triggerAsyncConnectorPing: firing job to trigger heartbeat");
-            getScheduler().fireJobAt(NAME+UUID.randomUUID(), this, null, new Date(System.currentTimeMillis()-1000 /* make sure it gets triggered immediately*/));
+            getScheduler().schedule(this, getScheduler().NOW().name(NAME+UUID.randomUUID()));
         } catch (Exception e) {
             logger.info("triggerAsyncConnectorPing: Could not trigger heartbeat: " + e);
         }

--- a/src/test/java/org/apache/sling/discovery/base/its/setup/VirtualInstanceBuilder.java
+++ b/src/test/java/org/apache/sling/discovery/base/its/setup/VirtualInstanceBuilder.java
@@ -22,9 +22,6 @@ import java.util.UUID;
 
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.Scheduler;
-import org.apache.sling.commons.scheduler.impl.QuartzScheduler;
-import org.apache.sling.commons.threads.ThreadPoolManager;
-import org.apache.sling.commons.threads.impl.DefaultThreadPoolManager;
 import org.apache.sling.discovery.base.commons.BaseDiscoveryService;
 import org.apache.sling.discovery.base.commons.ClusterViewService;
 import org.apache.sling.discovery.base.commons.ViewChecker;
@@ -34,30 +31,18 @@ import org.apache.sling.discovery.base.connectors.ping.ConnectorRegistry;
 import org.apache.sling.discovery.base.connectors.ping.ConnectorRegistryImpl;
 import org.apache.sling.discovery.base.its.setup.mock.ArtificialDelay;
 import org.apache.sling.discovery.base.its.setup.mock.FailingScheduler;
+import org.apache.sling.discovery.commons.providers.base.DummyScheduler;
 import org.apache.sling.discovery.commons.providers.spi.base.DummySlingSettingsService;
 import org.apache.sling.settings.SlingSettingsService;
-
-import junitx.util.PrivateAccessor;
 
 public abstract class VirtualInstanceBuilder {
 
     private static Scheduler singletonScheduler = null;
     
     public static Scheduler getSingletonScheduler() throws Exception {
-        if (singletonScheduler!=null) {
-            return singletonScheduler;
+        if (singletonScheduler == null) {
+            singletonScheduler = new DummyScheduler();
         }
-        final Scheduler newscheduler = new QuartzScheduler();
-        final ThreadPoolManager tpm = new DefaultThreadPoolManager(null, null);
-        try {
-            PrivateAccessor.invoke(newscheduler, "bindThreadPoolManager",
-                    new Class[] { ThreadPoolManager.class },
-                    new Object[] { tpm });
-        } catch (Throwable e1) {
-            org.junit.Assert.fail(e1.toString());
-        }
-        OSGiMock.activate(newscheduler);
-        singletonScheduler = newscheduler;
         return singletonScheduler;
     }
 

--- a/src/test/java/org/apache/sling/discovery/base/its/setup/mock/FailingScheduler.java
+++ b/src/test/java/org/apache/sling/discovery/base/its/setup/mock/FailingScheduler.java
@@ -23,10 +23,14 @@ import java.util.Date;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
+import org.mockito.Mockito;
 
 public class FailingScheduler implements Scheduler {
     
+    private final ScheduleOptions options = Mockito.mock(ScheduleOptions.class);
+
     @Override
     public void removeJob(String name) throws NoSuchElementException {
         // nothing to do here
@@ -68,5 +72,42 @@ public class FailingScheduler implements Scheduler {
     public void addJob(String name, Object job, Map<String, Serializable> config, String schedulingExpression,
             boolean canRunConcurrently) throws Exception {
         throw new Exception("cos you are really worth it");
+    }
+
+    @Override
+    public boolean schedule(Object job, ScheduleOptions options) {
+        // fails on purpose
+        return false;
+    }
+
+    @Override
+    public boolean unschedule(String jobName) {
+        // fails on purpose
+        return false;
+    }
+
+    @Override
+    public ScheduleOptions NOW() {
+        return options;
+    }
+
+    @Override
+    public ScheduleOptions NOW(int times, long period) {
+        return options;
+    }
+
+    @Override
+    public ScheduleOptions AT(Date date) {
+        return options;
+    }
+
+    @Override
+    public ScheduleOptions AT(Date date, int times, long period) {
+        return options;
+    }
+
+    @Override
+    public ScheduleOptions EXPR(String expression) {
+        return options;
     }
 }


### PR DESCRIPTION
…tead of relying on availability on default thread pool

Note that this is part 2/3 as all 3 discovery.commons/.base/.oak need to be updated