### PR TITLE
SLING-13221 Remove test dependency on commons-lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,15 +266,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-        	<groupId>org.apache.sling</groupId>
-        	<artifactId>org.apache.sling.jcr.resource</artifactId>
-        	<version>2.7.4</version>
-        	<scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.2</version>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.jcr.resource</artifactId>
+            <version>3.3.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
resolves a moderate severity Dependabot Alert

Also bump the org.apache.sling.jcr.resource test dependency to the latest since that is the only thing that was using the commons-lang code.  The later versions of that artifact migrated to commons-lang3.