### PR TITLE
SLING-13223 Improve TopologyRequestValidator encryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
                  <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <argLine>-Xmx2048m</argLine>
+                    <argLine>-Xmx2048m ${jacoco.command}</argLine>
                     <excludedGroups>${sling.excluded.surefire.groups}</excludedGroups>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
 
     <properties>
         <jackrabbit.version>2.14.3</jackrabbit.version>
+        <surefire.maxmem>-Xmx2048m</surefire.maxmem>
+        <surefire.argline>${surefire.maxmem}</surefire.argline>
     </properties>
 
     <build>
@@ -51,7 +53,7 @@
                  <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <argLine>-Xmx2048m ${jacoco.command}</argLine>
+                    <argLine>${surefire.argline}</argLine>
                     <excludedGroups>${sling.excluded.surefire.groups}</excludedGroups>
                 </configuration>
             </plugin>
@@ -284,5 +286,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- override to pass the extra jacoco arguments to surefire-->
+        <profile>
+            <id>jacoco-report</id>
+            <properties>
+                <surefire.argline>${surefire.maxmem} ${jacoco.command}</surefire.argline>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/org/apache/sling/discovery/base/connectors/ping/TopologyRequestValidator.java
+++ b/src/main/java/org/apache/sling/discovery/base/connectors/ping/TopologyRequestValidator.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
-import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -29,7 +28,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.KeySpec;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,7 +43,7 @@ import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import jakarta.json.Json;
@@ -82,6 +80,16 @@ public class TopologyRequestValidator {
      * Minimum number of keys to keep in memory.
      */
     private static final int MINKEYS = 3;
+
+    /**
+     * GCM authentication tag length in bits.
+     */
+    private static final int GCM_TAG_LENGTH = 128;
+
+    /**
+     * GCM nonce length in bytes.
+     */
+    private static final int GCM_NONCE_LENGTH = 12;
 
     /**
      * true if trust information should be in request headers.
@@ -170,7 +178,7 @@ public class TopologyRequestValidator {
                 throw new IOException("Unable to Encrypt Message " + e.getMessage());
             } catch (InvalidKeySpecException e) {
                 throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (InvalidParameterSpecException e) {
+            } catch (InvalidAlgorithmParameterException e) {
                 throw new IOException("Unable to Encrypt Message " + e.getMessage());
             }
 
@@ -419,9 +427,9 @@ public class TopologyRequestValidator {
     }
 
     /**
-     * Decrypt the body.
+     * Decrypt the body using AES/GCM mode with authenticated encryption.
      *
-     * @param jsonArray the encrypted payload
+     * @param jsonArray the encrypted payload (nonce, ciphertext, authTag)
      * @return the decrypted payload.
      * @throws IllegalBlockSizeException
      * @throws BadPaddingException
@@ -435,16 +443,19 @@ public class TopologyRequestValidator {
     private String decrypt(JsonArray jsonArray) throws IllegalBlockSizeException,
             BadPaddingException, UnsupportedEncodingException, InvalidKeyException,
             NoSuchAlgorithmException, NoSuchPaddingException, InvalidAlgorithmParameterException, InvalidKeySpecException {
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-        cipher.init(Cipher.DECRYPT_MODE, getCipherKey(Base64.decodeBase64(jsonArray.get(0).toString().getBytes("UTF-8"))), new IvParameterSpec(Base64.decodeBase64(jsonArray.get(1).toString().getBytes("UTF-8"))));
-        return new String(cipher.doFinal(Base64.decodeBase64(jsonArray.get(2).toString().getBytes("UTF-8"))));
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        byte[] nonce = Base64.decodeBase64(jsonArray.get(0).toString().getBytes("UTF-8"));
+        byte[] ciphertext = Base64.decodeBase64(jsonArray.get(1).toString().getBytes("UTF-8"));
+        GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, nonce);
+        cipher.init(Cipher.DECRYPT_MODE, getCipherKey(nonce), spec);
+        return new String(cipher.doFinal(ciphertext), "UTF-8");
     }
 
     /**
-     * Encrypt a payload with the numbed key/
+     * Encrypt a payload with AES/GCM mode with authenticated encryption.
      *
      * @param payload the payload.
-     * @return an encrypted version.
+     * @return an encrypted version (nonce, ciphertext).
      * @throws IllegalBlockSizeException
      * @throws BadPaddingException
      * @throws UnsupportedEncodingException
@@ -452,20 +463,20 @@ public class TopologyRequestValidator {
      * @throws NoSuchAlgorithmException
      * @throws NoSuchPaddingException
      * @throws InvalidKeySpecException
-     * @throws InvalidParameterSpecException
+     * @throws InvalidAlgorithmParameterException
      */
     private List<String> encrypt(String payload) throws IllegalBlockSizeException,
             BadPaddingException, UnsupportedEncodingException, InvalidKeyException,
-            NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeySpecException, InvalidParameterSpecException {
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-        byte[] salt = new byte[9];
-        random.nextBytes(salt);
-        cipher.init(Cipher.ENCRYPT_MODE, getCipherKey(salt));
-        AlgorithmParameters params = cipher.getParameters();
+            NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeySpecException, InvalidAlgorithmParameterException {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        byte[] nonce = new byte[GCM_NONCE_LENGTH];
+        random.nextBytes(nonce);
+        GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, getCipherKey(nonce), spec);
+        byte[] ciphertext = cipher.doFinal(payload.getBytes("UTF-8"));
         List<String> encrypted = new ArrayList<String>();
-        encrypted.add(new String(Base64.encodeBase64(salt)));
-        encrypted.add(new String(Base64.encodeBase64(params.getParameterSpec(IvParameterSpec.class).getIV())));
-        encrypted.add(new String(Base64.encodeBase64(cipher.doFinal(payload.getBytes("UTF-8")))));
+        encrypted.add(new String(Base64.encodeBase64(nonce), "UTF-8"));
+        encrypted.add(new String(Base64.encodeBase64(ciphertext), "UTF-8"));
         return encrypted;
     }
 
@@ -480,7 +491,7 @@ public class TopologyRequestValidator {
         // The NIST guidelines suggest the iteration count to be at least 10000
         // Using longer hashes (SHA-256 and higher) increases the attacker's costs
         SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-        KeySpec spec = new PBEKeySpec(sharedKey.toCharArray(), salt, 10000, 128);
+        KeySpec spec = new PBEKeySpec(sharedKey.toCharArray(), salt, 10000, 256);
         SecretKey tmp = factory.generateSecret(spec);
         return new SecretKeySpec(tmp.getEncoded(), "AES");
     }

--- a/src/main/java/org/apache/sling/discovery/base/connectors/ping/TopologyRequestValidator.java
+++ b/src/main/java/org/apache/sling/discovery/base/connectors/ping/TopologyRequestValidator.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -161,24 +162,9 @@ public class TopologyRequestValidator {
                 StringWriter writer = new StringWriter();
                 Json.createGenerator(writer).write(json.build()).close();
                 return writer.toString();
-            } catch (InvalidKeyException e) {
-                e.printStackTrace();
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (IllegalBlockSizeException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (BadPaddingException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (UnsupportedEncodingException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (NoSuchAlgorithmException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (NoSuchPaddingException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (JsonException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (InvalidKeySpecException e) {
-                throw new IOException("Unable to Encrypt Message " + e.getMessage());
-            } catch (InvalidAlgorithmParameterException e) {
+            } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | NoSuchAlgorithmException
+                    | NoSuchPaddingException | JsonException | InvalidKeySpecException
+                    | InvalidAlgorithmParameterException e) {
                 throw new IOException("Unable to Encrypt Message " + e.getMessage());
             }
 
@@ -235,22 +221,10 @@ public class TopologyRequestValidator {
                         if (json.containsKey("payload")) {
                             return decrypt(json.getJsonArray("payload"));
                         }
-                    } catch (JsonException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (InvalidKeyException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (IllegalBlockSizeException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (BadPaddingException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (NoSuchAlgorithmException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (NoSuchPaddingException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (InvalidAlgorithmParameterException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
-                    } catch (InvalidKeySpecException e) {
-                        throw new IOException("Encrypted Message is in the correct json format");
+                    } catch (JsonException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException
+                            | NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException
+                            | InvalidKeySpecException e) {
+                        throw new IOException("Encrypted Message is not in the correct json format");
                     }
 
                 }
@@ -441,14 +415,14 @@ public class TopologyRequestValidator {
      * @throws InvalidAlgorithmParameterException
      */
     private String decrypt(JsonArray jsonArray) throws IllegalBlockSizeException,
-            BadPaddingException, UnsupportedEncodingException, InvalidKeyException,
-            NoSuchAlgorithmException, NoSuchPaddingException, InvalidAlgorithmParameterException, InvalidKeySpecException {
+            BadPaddingException, InvalidKeyException, NoSuchAlgorithmException,
+            NoSuchPaddingException, InvalidAlgorithmParameterException, InvalidKeySpecException {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-        byte[] nonce = Base64.decodeBase64(jsonArray.get(0).toString().getBytes("UTF-8"));
-        byte[] ciphertext = Base64.decodeBase64(jsonArray.get(1).toString().getBytes("UTF-8"));
+        byte[] nonce = Base64.decodeBase64(jsonArray.get(0).toString().getBytes(StandardCharsets.UTF_8));
+        byte[] ciphertext = Base64.decodeBase64(jsonArray.get(1).toString().getBytes(StandardCharsets.UTF_8));
         GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, nonce);
         cipher.init(Cipher.DECRYPT_MODE, getCipherKey(nonce), spec);
-        return new String(cipher.doFinal(ciphertext), "UTF-8");
+        return new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
     }
 
     /**
@@ -466,17 +440,17 @@ public class TopologyRequestValidator {
      * @throws InvalidAlgorithmParameterException
      */
     private List<String> encrypt(String payload) throws IllegalBlockSizeException,
-            BadPaddingException, UnsupportedEncodingException, InvalidKeyException,
-            NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeySpecException, InvalidAlgorithmParameterException {
+            BadPaddingException, InvalidKeyException, NoSuchAlgorithmException,
+            NoSuchPaddingException, InvalidKeySpecException, InvalidAlgorithmParameterException {
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         byte[] nonce = new byte[GCM_NONCE_LENGTH];
         random.nextBytes(nonce);
         GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, nonce);
         cipher.init(Cipher.ENCRYPT_MODE, getCipherKey(nonce), spec);
-        byte[] ciphertext = cipher.doFinal(payload.getBytes("UTF-8"));
-        List<String> encrypted = new ArrayList<String>();
-        encrypted.add(new String(Base64.encodeBase64(nonce), "UTF-8"));
-        encrypted.add(new String(Base64.encodeBase64(ciphertext), "UTF-8"));
+        byte[] ciphertext = cipher.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        List<String> encrypted = new ArrayList<>();
+        encrypted.add(new String(Base64.encodeBase64(nonce), StandardCharsets.UTF_8));
+        encrypted.add(new String(Base64.encodeBase64(ciphertext), StandardCharsets.UTF_8));
         return encrypted;
     }
 


### PR DESCRIPTION
The issue with SonarQube's "Encryption algorithms should be used with secure mode and padding scheme" warning is actually about using insecure cipher modes and padding.

Here is the proposed changes (as proposed by copilot):

1. Switch from AES/CBC to AES/GCM - GCM (Galois/Counter Mode) is authenticated encryption that provides both confidentiality and integrity protection in a single operation, eliminating padding oracle vulnerabilities.
2. Removed PKCS5Padding - PKCS5Padding is vulnerable to padding oracle attacks. GCM uses "NoPadding" since it's a stream cipher mode.
3. Increased key size to 256-bit - Stronger cryptographic key for AES.
4. Updated nonce handling - GCM uses a 12-byte nonce (IV) instead of a salt, which is the standard practice.
5. Simplified payload structure - GCM automatically handles the authentication tag, so we only need to transmit the nonce and ciphertext.

This approach satisfies SonarQube's requirements by using a secure cipher mode (GCM) with proper cryptographic standards, while eliminating the padding scheme vulnerability that was causing the warning.